### PR TITLE
.DS_Store banished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Added a `.gitignore` file so we can get rid of all those pesky .DS_Store files...